### PR TITLE
doc: Updating delivery problems details to POST method

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Crie uma rota para listar todos os problemas de uma encomenda baseado no ID da e
 
 Exemplo de requisição: `GET https://fastfeet.com/delivery/2/problems`
 
-Crie uma rota para o entregador cadastrar problemas na entrega apenas informando seu ID de cadastro (ID do banco de dados);
+Crie uma rota para o entregador cadastrar problemas na entrega apenas informando seu ID de cadastro (ID da encomenda no banco de dados);
 
 Exemplo de requisição: `POST https://fastfeet.com/delivery/3/problems`
 


### PR DESCRIPTION
Hi devs,

I found a problem in the documentation of challenge 3 of the gostack 10.  
In the post method of the **delivery problems**, the documentation said to create an route to the deliveryman register a problem into delivery passing only your ID... With that appears that is the Deliveryman ID, and not the Delivery ID. I fixed the README with this info.

Thanks for all, rocketseat!